### PR TITLE
Slow down eating visualization

### DIFF
--- a/philosophers/philosophers.cpp
+++ b/philosophers/philosophers.cpp
@@ -71,7 +71,7 @@
 /**
  * @brief How long a philosopher eats when he has both forks (in us).
  */
-#define EATTIME     (25600)
+#define EATTIME     (1000000)
 
 /**
  * @brief How long to wait between display refreshes (in us).


### PR DESCRIPTION
Having EATTIME be 1/40th of a second makes the simulation pretty difficult to follow.
