### PR TITLE
reader.cpp: Fixed strncpy() not copying null terminator

### DIFF
--- a/reader/reader.cpp
+++ b/reader/reader.cpp
@@ -179,6 +179,7 @@ int main()
     size_t len = strlen(buffer);
     char *string = new char[len];
     strncpy(string, buffer, len);
+    string[len-1] = '\0';
 
     // Add the string to the Queue
     queue.push_back(string);


### PR DESCRIPTION
I don't know if this is meant to be fixed by the student, but `strncpy()` does **not** copy the null terminator to the destination string. It seems that `strncpy()` pads the destination buffer with `NULL` only if its smaller than the `len` argument that is passed in. I don't think `strncpy()` should be used with null terminated strings, which is what is being done here. It's safer to use `strlcpy()` or to terminate the string on the user's side.
